### PR TITLE
fix: MediaPlayerScreen: flicering subtitle

### DIFF
--- a/src/app/player/[id].tsx
+++ b/src/app/player/[id].tsx
@@ -30,6 +30,11 @@ export default function MediaPlayerScreen() {
     null
   );
 
+  // Add state for frozen subtitle when in range mode
+  const [frozenSubtitle, setFrozenSubtitle] = useState<SubtitleEntry | null>(
+    null
+  );
+
   const mediaPlayer = useVideoPlayer(mediaSource, (player) => {
     player.showNowPlayingNotification = true;
     player.timeUpdateEventInterval = 0.5;
@@ -57,6 +62,17 @@ export default function MediaPlayerScreen() {
     mediaPlayer,
     currentTime,
   });
+
+  // Effect to handle frozen subtitle when entering/exiting range mode
+  useEffect(() => {
+    if (isRangeMode && !frozenSubtitle) {
+      // When entering range mode, freeze the current subtitle
+      setFrozenSubtitle(currentSubtitle);
+    } else if (!isRangeMode && frozenSubtitle) {
+      // When exiting range mode, clear the frozen subtitle
+      setFrozenSubtitle(null);
+    }
+  }, [isRangeMode, currentSubtitle, frozenSubtitle]);
 
   const { isPlaying } = useEvent(mediaPlayer, "playingChange", {
     isPlaying: mediaPlayer.playing,
@@ -170,7 +186,9 @@ export default function MediaPlayerScreen() {
         onPress={handleSubtitlePress}
         disabled={isRangeMode}
       >
-        <Text>{currentSubtitle?.text}</Text>
+        <Text>
+          {isRangeMode ? frozenSubtitle?.text : currentSubtitle?.text}
+        </Text>
       </TouchableOpacity>
 
       <RangeControls


### PR DESCRIPTION
A subtitle in RangeMode could be change because the start/end time of it is identical to the prev/next one which causes flickering subtitles.
=> My solution is to froze the current subtitle so matter where the playback time goes, the text of the current subtitle stays the same.